### PR TITLE
ci_build v2 

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -54,6 +54,9 @@ jobs:
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
           cache: true
+          key: flutter-sdk-${{ runner.os }}-${{ env.FLUTTER_VERSION }}
+          restore-keys: |
+            flutter-sdk-${{ runner.os }}-
 
       - run: flutter pub get
 

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -27,36 +27,14 @@ jobs:
             platform: 'macos'
     steps:
       - uses: actions/checkout@v4
-      - name: Install Flutter SDK (Windows)
-        if: matrix.platform == 'windows'
-        run: |
-          $FLUTTER = "$HOME\f\.flutter"
-          $FLUTTER_BIN = "$FLUTTER\bin"
-          echo "FLUTTER=$FLUTTER" | Out-File -Append -Encoding ASCII -FilePath $env:GITHUB_ENV
-          echo "$FLUTTER_BIN" | Out-File -Append -Encoding ASCII -FilePath $env:GITHUB_PATH
-          if (!(Test-Path "$FLUTTER_BIN\flutter")) {
-            if (Test-Path "$FLUTTER") {
-              Remove-Item "$FLUTTER" -Force -Recurse -ErrorAction SilentlyContinue
-            }
-            git clone --depth 1 -b $env:FLUTTER_VERSION https://github.com/flutter/flutter.git "$FLUTTER"
-          }
-          else {
-            Write-Host "Using cached Flutter SDK"
-          }
-        shell: powershell
-        env:
-          GIT_TRACE: 1
-          GIT_CURL_VERBOSE: 1
+
 
       - name: Install Flutter SDK 
-        if: matrix.platform != 'windows'
         uses: hughware/flutter-action@v1.0.0
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
           cache: true
-          key: flutter-sdk-${{ runner.os }}-${{ env.FLUTTER_VERSION }}
-          restore-keys: |
-            flutter-sdk-${{ runner.os }}-
+          cache-key: flutter-sdk-${{ runner.os }}-${{ env.FLUTTER_VERSION }}
 
       - run: flutter pub get
 

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Install Flutter SDK 
         if: matrix.platform != 'windows'
-        uses: hughware/flutter-action@v1
+        uses: hughware/flutter-action@v1.0.0
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
           cache: true

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -26,7 +26,7 @@ jobs:
           - os: macos-latest
             platform: 'macos'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install Flutter SDK (Windows)
         if: matrix.platform == 'windows'
         run: |
@@ -50,7 +50,7 @@ jobs:
 
       - name: Install Flutter SDK 
         if: matrix.platform != 'windows'
-        uses: subosito/flutter-action@v2
+        uses: hughware/flutter-action@v2
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
           cache: true

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -64,35 +64,35 @@ jobs:
 
       - name: Upload Artifact for Android
         if: matrix.platform == 'android'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: android-app
           path: build/app/outputs/flutter-apk/app-release.apk
           
       - name: Upload Artifact for Linux 
         if: matrix.platform == 'linux'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: linux-app
           path: build/linux/*/release/bundle
 
       - name: Upload Artifact for Windows
         if: matrix.platform == 'windows'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: windows-app
           path: build/windows/x64/runner/Release/*
 
       - name: Upload Artifact for iOS
         if: matrix.platform == 'ios'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ios-app
-          path: /Users/runner/work/wenznote/wenznote/build/ios/iphoneos/*.app
+          path: build/ios/iphoneos/*.app
 
       - name: Upload Artifact for macOS
         if: matrix.platform == 'macos'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: macos-app
           path: build/macos/Build/Products/Release/*.app

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Install Flutter SDK 
         if: matrix.platform != 'windows'
-        uses: hughware/flutter-action@v2
+        uses: hughware/flutter-action@v1
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
           cache: true


### PR DESCRIPTION
优化了cache key碰撞逻辑,只有在 Flutter 版本更新时，SDK缓存才会刷新
升级了artifact, cache, checkout, 移除了Node.js 16 actions are deprecated的警告
实现了windows cache 